### PR TITLE
Change branch names now that not restricted by GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,6 @@ deploy:
   skip_cleanup: true
   github_token: $GITHUB_TOKEN
   on:
-    branch: gh-pages
-  target_branch: master
+    branch: master
+  target_branch: gh-pages
   local_dir: _book


### PR DESCRIPTION
Change branch names now that not restricted by GitHub. `master` should be the default branch.